### PR TITLE
Decouple subnet toggles and select Redshift subnets by accessibility

### DIFF
--- a/examples/redshift/main.tf
+++ b/examples/redshift/main.tf
@@ -7,6 +7,7 @@ variable "vpc_config" {
     vpc_cidr                = "10.126.3.0/24"
     transit_gateway_enabled = true
     public_subnet_enabled   = true
+    private_subnet_enabled  = false
   }
 }
 

--- a/redshift_instance.tf
+++ b/redshift_instance.tf
@@ -61,8 +61,12 @@ module "redshift" {
   create_security_group  = false
   vpc_security_group_ids = each.value.vpc_security_group_ids
 
-  create_subnet_group      = each.value.create_subnet_group
-  subnet_ids               = [for _, value in one(module.vpc).public_subnet_attributes_by_az : value.id]
+  create_subnet_group = each.value.create_subnet_group
+  subnet_ids = each.value.subnet_ids != null ? each.value.subnet_ids : (
+    each.value.publicly_accessible
+    ? [for _, value in one(module.vpc).public_subnet_attributes_by_az : value.id]
+    : [for _, value in one(module.vpc).private_subnet_attributes_by_az : value.id]
+  )
   subnet_group_name        = each.value.subnet_group_name
   subnet_group_description = each.value.subnet_group_description
   subnet_group_tags        = merge(local.tags, each.value.subnet_group_tags)

--- a/variables.tf
+++ b/variables.tf
@@ -36,7 +36,8 @@ variable "vpc_config" {
     vpc_cidr                = string,
     az_count                = optional(number, 3),
     transit_gateway_enabled = optional(bool, true),
-    public_subnet_enabled   = optional(bool, false)
+    public_subnet_enabled   = optional(bool, false),
+    private_subnet_enabled  = optional(bool, true)
   })
 
   default = null

--- a/vpc.tf
+++ b/vpc.tf
@@ -1,10 +1,11 @@
 locals {
   transit_gateway_enabled = var.vpc_config != null ? var.vpc_config.transit_gateway_enabled : false
-  public_subnet_enabled   = var.vpc_config != null ? var.vpc_config.public_subnet_enabled   : false
+  public_subnet_enabled   = var.vpc_config != null ? var.vpc_config.public_subnet_enabled : false
+  private_subnet_enabled  = var.vpc_config != null ? var.vpc_config.private_subnet_enabled : false
   vpc_azs = var.vpc_config != null ? (
     var.vpc_config.az_count != null
-      ? slice(data.aws_availability_zones.current.names, 0, var.vpc_config.az_count)
-      : data.aws_availability_zones.current.names
+    ? slice(data.aws_availability_zones.current.names, 0, var.vpc_config.az_count)
+    : data.aws_availability_zones.current.names
   ) : []
 }
 
@@ -42,11 +43,12 @@ module "vpc" {
       public = {
         netmask = 26
       }
-      } : {
+    } : {},
+    local.private_subnet_enabled ? {
       private = {
         netmask = 26
       }
-    },
+    } : {},
     var.vpc_config.transit_gateway_enabled ? {
       transit_gateway = {
         netmask                                         = 28
@@ -85,7 +87,7 @@ resource "aws_route" "public_subnet_prefix_list_routes" {
     var.vpc_config != null &&
     local.public_subnet_enabled &&
     local.transit_gateway_enabled
-  ) ? {
+    ) ? {
     for az in local.vpc_azs : az => az
   } : {}
 


### PR DESCRIPTION
### Motivation
- Allow independent enablement of public and private subnets instead of mutually exclusive behavior. 
- Ensure private subnets are enabled by default for resources that expect private networking. 
- Make Redshift (and similar resources) choose subnet IDs based on whether the instance is `publicly_accessible` so public/private placement is automatic when `subnet_ids` is not provided. 

### Description
- Added `private_subnet_enabled` to the `vpc_config` input object with a default of `true` in `variables.tf`. 
- Introduced `local.private_subnet_enabled` and updated `module

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c3dfb14f148322ace9dc794d97fb3e)