### PR TITLE
Fix Redshift re-apply failure with empty security group IDs

### DIFF
--- a/redshift_instance.tf
+++ b/redshift_instance.tf
@@ -58,8 +58,10 @@ module "redshift" {
 
   vpc_id = one(module.vpc).vpc_attributes.id
 
-  create_security_group  = false
-  vpc_security_group_ids = each.value.vpc_security_group_ids
+  create_security_group = false
+  # Avoid passing an empty list to the Redshift ModifyCluster API on re-apply.
+  # An empty list is treated as an explicit update and Redshift rejects it.
+  vpc_security_group_ids = length(each.value.vpc_security_group_ids) > 0 ? each.value.vpc_security_group_ids : null
 
   create_subnet_group = each.value.create_subnet_group
   subnet_ids = each.value.subnet_ids != null ? each.value.subnet_ids : (


### PR DESCRIPTION
### Motivation
- Avoid the Redshift `ModifyCluster` API validation error (`InvalidParameterValue: The vpc-security-group-ids parameter must have at least one argument`) that happens when an empty list is sent for `vpc_security_group_ids` on re-apply.

### Description
- Update `redshift_instance.tf` to set `vpc_security_group_ids = length(each.value.vpc_security_group_ids) > 0 ? each.value.vpc_security_group_ids : null` and add a comment so Terraform omits the argument instead of sending an empty list.

### Testing
- Ran `terraform fmt` and `terraform fmt -check -diff`, both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ca7d97f82c83228c6f58aa5f0d7316)