### PR TITLE
Always create Redshift SG and support per-instance ingress_whitelist_cidrs

### DIFF
--- a/examples/redshift/main.tf
+++ b/examples/redshift/main.tf
@@ -56,6 +56,12 @@ module "shared_resources" {
       enhanced_vpc_routing   = true
       allow_version_upgrade  = false
       vpc_security_group_ids = []
+      ingress_whitelist_cidrs = [
+        {
+          cidr        = "10.0.0.0/8"
+          description = "Allow internal network access to Redshift"
+        }
+      ]
 
       # snapshot_arn = ""
       # owner_account = ""

--- a/redshift_instance.tf
+++ b/redshift_instance.tf
@@ -8,10 +8,7 @@ resource "aws_eip" "redshift_public_ip" {
 }
 
 resource "aws_security_group" "redshift_networking_routes" {
-  for_each = (
-    var.vpc_config != null &&
-    length(var.public_subnet_prefix_list_entries) > 0
-  ) ? var.redshift_instances : {}
+  for_each = var.vpc_config != null ? var.redshift_instances : {}
 
   name        = "${lower(var.application_name)}-${each.key}-networking-routes"
   description = "Allow Redshift access from networking routes"
@@ -20,7 +17,7 @@ resource "aws_security_group" "redshift_networking_routes" {
 
   dynamic "ingress" {
     for_each = {
-      for route in var.public_subnet_prefix_list_entries : route.cidr => route
+      for route in each.value.ingress_whitelist_cidrs : route.cidr => route
     }
 
     content {

--- a/variables.tf
+++ b/variables.tf
@@ -368,7 +368,11 @@ variable "redshift_instances" {
     availability_zone                    = optional(string, null)
     availability_zone_relocation_enabled = optional(bool, null)
 
-    port                         = optional(number, 5439)
+    port = optional(number, 5439)
+    ingress_whitelist_cidrs = optional(list(object({
+      cidr        = string
+      description = optional(string, null)
+    })), [])
     preferred_maintenance_window = optional(string, "sat:10:00-sat:10:30")
 
     automated_snapshot_retention_period = optional(number, null)


### PR DESCRIPTION
### Motivation
- Decouple Redshift security group ingress from networking account routes so the SG can be created independently of external route lists.
- Ensure a security group is always created for each Redshift instance when `vpc_config` is enabled, and block all ingress when no whitelist is supplied.
- Allow callers to explicitly supply ingress allowlists per Redshift instance so ingress rules are predictable and self-contained.

### Description
- Changed the `aws_security_group.redshift_networking_routes` resource to create a SG for every Redshift instance when `vpc_config` is set by using `for_each = var.vpc_config != null ? var.redshift_instances : {}` in `redshift_instance.tf`.
- Replaced dynamic ingress source iteration from `var.public_subnet_prefix_list_entries` to `each.value.ingress_whitelist_cidrs` so per-instance CIDR entries drive ingress rules in `redshift_instance.tf`.
- Added a new per-instance input `ingress_whitelist_cidrs` to the `redshift_instances` variable schema in `variables.tf` with type `list(object({ cidr = string, description = optional(string, null) }))` and default `[]`.
- Updated the Redshift example in `examples/redshift/main.tf` to demonstrate passing `ingress_whitelist_cidrs` and preserved the existing egress rule (`0.0.0.0/0`).

### Testing
- Ran `terraform fmt -recursive` which completed successfully.
- Ran `terraform validate` which failed because external modules are not installed in this environment and `terraform init` is required, so validation could not complete here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69cbb86f6fb083229de9a41efa1e89e1)