### PR TITLE
Add requested Redshift ingress CIDRs to example config

### DIFF
--- a/examples/redshift/main.tf
+++ b/examples/redshift/main.tf
@@ -60,6 +60,42 @@ module "shared_resources" {
         {
           cidr        = "10.0.0.0/8"
           description = "Allow internal network access to Redshift"
+        },
+        {
+          cidr        = "18.192.2.142/32"
+          description = "Metabase Cloud"
+        },
+        {
+          cidr        = "10.120.2.0/24"
+          description = "AWS Client VPN"
+        },
+        {
+          cidr        = "172.31.0.0/16"
+          description = "Redshift (Mailman)"
+        },
+        {
+          cidr        = "3.65.184.173/32"
+          description = "Metabase Cloud"
+        },
+        {
+          cidr        = "10.192.0.0/16"
+          description = "MWAA Airflow"
+        },
+        {
+          cidr        = "10.168.1.0/24"
+          description = "guidion-data-acceptance-ecs"
+        },
+        {
+          cidr        = "10.128.1.0/24"
+          description = "guidion-data-development-ecs"
+        },
+        {
+          cidr        = "10.208.0.0/24"
+          description = "guidion-data-production-powerbi-gateway"
+        },
+        {
+          cidr        = "18.184.191.58/32"
+          description = "Metabase Cloud"
         }
       ]
 


### PR DESCRIPTION
### Motivation
- The Redshift example needed the full set of ingress CIDR routes shown in the provided screenshot so the example reflects actual allowed sources for access.

### Description
- Added multiple `ingress_whitelist_cidrs` entries to `examples/redshift/main.tf`, including CIDRs and descriptions for Metabase Cloud, AWS Client VPN, Redshift (Mailman), MWAA Airflow, and several environment-specific ECS and gateway networks.
- Kept the existing `10.0.0.0/8` internal access rule and appended the new routes after it.
- Ran `terraform fmt` on the modified example file to normalize formatting.

### Testing
- Ran `terraform fmt examples/redshift/main.tf`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69cbd1a6cdc483229dd08bca07438627)